### PR TITLE
Updating plugin versions and organising dependencies 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,3 @@
-val appDependencies =
-  Seq(
-    "uk.gov.hmrc"       %% "logback-json-logger"  % "4.2.0",
-    "com.typesafe.play" %% "play-json"            % "2.6.10",
-    "org.scalatest"     %% "scalatest"            % "3.0.5" % Test,
-    "org.pegdown"       %  "pegdown"              % "1.6.0" % Test
-  )
-
 lazy val root = (project in file("."))
   .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory)
   .settings(
@@ -14,7 +6,7 @@ lazy val root = (project in file("."))
     makePublicallyAvailableOnBintray := true,
     scalaVersion := "2.12.12",
     crossScalaVersions := Seq("2.11.12", "2.12.12"),
-    libraryDependencies ++= appDependencies,
+    libraryDependencies ++= Dependencies.compile ++ Dependencies.test,
     libraryDependencies := {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, scalaMajor)) if scalaMajor == 12 =>
@@ -28,9 +20,5 @@ lazy val root = (project in file("."))
         case _ =>
           libraryDependencies.value
       }
-    },
-    resolvers := Seq(
-      Resolver.bintrayRepo("hmrc", "releases"),
-      Resolver.typesafeRepo("releases")
-    )
+    }
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,14 @@
+import sbt._
+
+object Dependencies {
+
+  val compile =
+    Seq(
+      "uk.gov.hmrc" %% "logback-json-logger" % "4.2.0",
+      "com.typesafe.play" %% "play-json" % "2.6.10"
+    )
+  val test =
+    Seq("org.scalatest" %% "scalatest" % "3.0.5" % Test,
+      "org.pegdown" % "pegdown" % "1.6.0" % Test)
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,8 @@ resolvers += Resolver.url("hmrc-sbt-plugin-releases",
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.13.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.13.0")


### PR DESCRIPTION
Removed resolvers from build.sbt as they should come from sbt-auto-build plugin.
Doing this before upgrading Gatling version. 