### PR TITLE
PLATUI-963: Removed `ConnectionHeader("close")` from HttpConfiguration.

### DIFF
--- a/src/main/scala/uk/gov/hmrc/performance/conf/HttpConfiguration.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/conf/HttpConfiguration.scala
@@ -18,21 +18,30 @@ package uk.gov.hmrc.performance.conf
 
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
+import io.gatling.http.protocol.HttpProtocolBuilder
 
 trait HttpConfiguration extends Configuration {
 
-  val headers = Map(
-    """Accept"""        -> """text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8""",
-    """Cache-Control""" -> """no-cache"""
-  )
+  /** Provides a `HttpProtocolBuilder` with preset configuration. This configures the HTTP protocol used in Gatling simulation.
+    *
+    * https://gatling.io/docs/3.4/http/http_protocol/
+    *
+    * Configurations to note:
+    *
+    * `True-Client-IP`:  Set to `java.util.Random()` value injected in the Gatling session during JourneySetup.journeys`.
+    * This value can be used to trace requests injected through the performance-test-runner library.
+    *
+    * `disableFollowRedirect`: Disables Gatling from following redirect automatically.This means the users of the library
+    * should make explicit redirect requests. https://gatling.io/docs/3.4/http/http_protocol/#response-handling-parameters
+    *
+    * Users of the library can override this default configuration by overriding `val httpProtocol` when extending `PerformanceTestRunner` trait.
+    */
 
-  val httpProtocol = http
+  val httpProtocol: HttpProtocolBuilder = http
     .acceptHeader("image/png,image/*;q=0.8,*/*;q=0.5")
     .acceptEncodingHeader("gzip, deflate")
     .acceptLanguageHeader("en-gb,en;q=0.5")
-    .connectionHeader("close")
     .userAgentHeader("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:25.0) Gecko/20100101 Firefox/25.0")
     .header("True-Client-IP", "${random}")
     .disableFollowRedirect
-
 }


### PR DESCRIPTION
The reason for introducing this header is unknown. Running tests without this header had no side effects. See issue ticket for more details.

Removed unused `headers` in HttpConfiguration.