### PR TITLE
PLATUI-1042: Replaced print statements with Logger framework

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,6 @@ object Dependencies {
 
   val compile =
     Seq(
-      "uk.gov.hmrc"          %% "logback-json-logger"       % "4.2.0",
       "com.typesafe.play"    %% "play-json"                 % "2.6.10",
       "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.4.2" % "provided"
     )

--- a/src/main/scala/uk/gov/hmrc/performance/simulation/JourneySetup.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/simulation/JourneySetup.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.performance.simulation
 import io.gatling.core.Predef.{constantUsersPerSec, exec, group, rampUsersPerSec, scenario, _}
 import io.gatling.core.controller.inject.open.OpenInjectionStep
 import io.gatling.core.structure.{PopulationBuilder, ScenarioBuilder}
+import org.slf4j.{Logger, LoggerFactory}
 import uk.gov.hmrc.performance.conf.{JourneyConfiguration, PerftestConfiguration}
 import uk.gov.hmrc.performance.feeder.CsvFeeder
 
@@ -28,6 +29,8 @@ import scala.util.Random
   */
 
 trait JourneySetup extends JourneyConfiguration with PerftestConfiguration {
+
+  private val logger: Logger = LoggerFactory.getLogger(classOf[JourneySetup])
 
   private[simulation] val parts = scala.collection.mutable.MutableList[JourneyPart]()
 
@@ -51,10 +54,10 @@ trait JourneySetup extends JourneyConfiguration with PerftestConfiguration {
     */
   protected def journeys: Seq[Journey] = {
 
-    println(s"Implemented journey parts: ${parts.map(_.id).mkString(", ")}")
+    logger.info(s"Implemented journey parts: ${parts.map(_.id).mkString(", ")}")
 
     definitions(labels).map { conf =>
-      println(s"Setting up scenario '${conf.id}' to run at ${conf.load} JPS and load to $loadPercentage %")
+      logger.info(s"Setting up scenario '${conf.id}' to run at ${conf.load} JPS and load to $loadPercentage %")
 
       val partsInJourney = conf.parts.map(p =>
         parts

--- a/src/main/scala/uk/gov/hmrc/performance/simulation/PerformanceTestRunner.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/simulation/PerformanceTestRunner.scala
@@ -17,20 +17,25 @@
 package uk.gov.hmrc.performance.simulation
 
 import io.gatling.core.Predef._
+import org.slf4j.{Logger, LoggerFactory}
 import uk.gov.hmrc.performance.conf.HttpConfiguration
 
 trait PerformanceTestRunner extends Simulation with HttpConfiguration with JourneySetup {
+
+  private val logger: Logger = LoggerFactory.getLogger(classOf[PerformanceTestRunner])
 
   def runSimulation(): Unit = {
 
     import scala.concurrent.duration._
     val timeoutAtEndOfTest: FiniteDuration = 5 minutes
 
-    println(s"Setting up simulation ")
+    logger.info(s"Setting up simulation ")
 
     if (runSingleUserJourney) {
 
-      println(s"'perftest.runSmokeTest' is set to true, ignoring all loads and running with only one user per journey!")
+      logger.info(
+        s"'perftest.runSmokeTest' is set to true, ignoring all loads and running with only one user per journey!"
+      )
 
       val injectedBuilders = journeys.map { scenario =>
         scenario.builder.inject(atOnceUsers(1))

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--This configurations is required to silence io.netty debug logs when running unit tests-->
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder >
+            <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger - %msg%n%rEx</pattern>
+        </encoder>
+        <immediateFlush>false</immediateFlush>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
- Using SLF4J instead of print statements to surface logs from the library. Gatling already uses SLF4J and Logback, so no additional dependencies required. 
- Upgrading to Gatling 3.4.2 has resulted in netty debug logs being surfaced when running unit tests. Added logback-test.xml to silence these logs.  
- Removed unused `logback-json-logger` dependency. 