### PR TITLE
PLATUI-969: Add Scala Docs for methods used by tenants.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,30 @@ class HelloWorldSimulation extends PerformanceTestRunner {
 }
 ```
 
+#### Using Gatling's Session API 
+
+Gatling's [Session API](https://gatling.io/docs/3.4/session/session_api/) is used to update
+Gatling's Session. To use the Session API with performance-test-runner, the `ChainBuilder` returned when executing a Session
+API should be converted into an `ActionBuilder`. The `ActionBuilder` then can be chained to a `setup` using `withActions`. 
+
+An example:
+
+```scala
+import io.gatling.core.action.builder.ActionBuilder
+import io.gatling.core.session.Session
+import io.gatling.core.Predef._
+
+/** Executes the Session API to set testId with value perf-12345 in Gatling's Session.
+ *  Converts the resulting ChainBuilder to a List[ActionBuilder] 
+ */
+val setRandomTestId: List[ActionBuilder] = {
+    exec((session: Session) => session.set("testId", "perf-12345}"))
+  }.actionBuilders
+
+// Chains the setRandomTestId using `withActions`
+setup("prep", "Prepare for test") withActions (setRandomTestId:_*)
+```
+
 ### More about the journey configuration.
 
 `description` will be assigned to the journey in the test report

--- a/src/main/scala/uk/gov/hmrc/performance/simulation/Journey.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/simulation/Journey.scala
@@ -28,19 +28,71 @@ trait Journey {
   def builder: ScenarioBuilder
 }
 
+/** Used to constructs parts of a Journey as listed in journeys.conf. The JourneyPart is defined within a performance test using
+  * uk.gov.hmrc.performance.simulation.JourneySetup.setup.
+  *
+  * To create a JourneyPart with uk.gov.hmrc.performance.simulation.JourneySetup.setup:
+  * {{{
+  * setup("login", "Login") withRequests (navigateToLoginPage, submitLogin)
+  * }}}
+  *
+  * @param id A unique id which should match the parts listed in journeys.conf
+  * @param description Description of the journey part surfaced in the gatling report.
+  */
 case class JourneyPart(id: String, description: String) {
 
   val ab                                             = scala.collection.mutable.MutableList[ActionBuilder]()
   var conditionallyRun: ChainBuilder => ChainBuilder = cb => cb
 
+  /** Used internally by uk.gov.hmrc.performance.simulation.JourneySetup.journeys to chain the requests and actions
+    * included in the JourneyPart.
+    *
+    * Applies [[conditionallyRun]] when a condition is specified in JourneyPart using [[toRunIf]].
+    *
+    * @return Requests and Actions of the JourneyPart as a `ChainBuilder`
+    */
   def builder: ChainBuilder =
     if (ab.isEmpty) throw new scala.IllegalArgumentException(s"'$id' must have at least one request")
     else conditionallyRun(ab.tail.foldLeft(exec(ab.head))((ex, trb) => ex.exec(trb)))
 
+  /** Chains HttpRequestBuilder to uk.gov.hmrc.performance.simulation.JourneySetup.setup.
+    * {{{
+    * setup("login-page", "Navigate to login page") withRequests navigateToLoginPage
+    * }}}
+    *
+    * @param requests of type `HttpRequestBuilder`
+    * @return JourneyPart for chaining additional requests, actions, and conditional runs
+    */
   def withRequests(requests: HttpRequestBuilder*): JourneyPart = {
     ab ++= requests.map(r => HttpRequestBuilder.toActionBuilder(r))
     this
   }
+
+  /** Chains ActionBuilders to a setup. ActionBuilder is what is passed to the DSL `exec()` method.
+    *
+    * For example, to add a PauseBuilder to a setup
+    * {{{
+    * val pause = new PauseBuilder(10 milliseconds, None)
+    * setup("pause-action", "pauses for 10 milliseconds") withActions(pause)
+    * }}}
+    *  Since, HttpRequestBuilder is also an ActionBuilder, these can be chained together.
+    *
+    *  In the below example `navigateToLoginPage` and `submitLogin` are of type `HttpRequestBuilder`
+    * {{{
+    * val pause = new PauseBuilder(1 milliseconds, None)
+    * setup("login", "Login") withActions(navigateToLoginPage, pause, submitLogin)
+    * }}}
+    *
+    *  To include a ChainBuilder, use `.actionBuilders` to covert it into a `List[ActionBuilder]` and pass it to
+    *  withActions as below.
+    *
+    *  In the below example, `sessionSetup` is of type `List[ActionBuilder]`
+    * {{{
+    * setup("session-setup", "Setting Session Value") withActions(sessionSetup:_*)
+    * }}}
+    * @param actions of type `ActionBuilder`
+    * @return JourneyPart for chaining additional requests, actions, and conditional runs
+    */
 
   def withActions(actions: ActionBuilder*): JourneyPart = {
     ab ++= actions

--- a/src/main/scala/uk/gov/hmrc/performance/simulation/PerformanceTestRunner.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/simulation/PerformanceTestRunner.scala
@@ -20,10 +20,26 @@ import io.gatling.core.Predef._
 import org.slf4j.{Logger, LoggerFactory}
 import uk.gov.hmrc.performance.conf.HttpConfiguration
 
+/** Trait extending `io.gatling.core.scenario.Simulation`. Use within a performance test to set up Journeys and invoke
+  *  `runSimulation()`, a method to configure the Simulation setup.
+  */
+
 trait PerformanceTestRunner extends Simulation with HttpConfiguration with JourneySetup {
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[PerformanceTestRunner])
 
+  /** Configures `io.gatling.core.scenario.Simulation.setUp`. This method is invoked from within a performance test.
+    *
+    * For smoke tests i.e when `uk.gov.hmrc.performance.conf.PerftestConfiguration.runSingleUserJourney`` is `true`,
+    * the setUp is configured to run only for 1 user.
+    *
+    * For a full test, the setUp is configured with:
+    *
+    *  - Journeys and the load to run
+    *  - Duration of the run
+    *  - Protocol configuration and
+    *  - Assertions
+    */
   def runSimulation(): Unit = {
 
     import scala.concurrent.duration._


### PR DESCRIPTION
Updated README to include using Gatling's Session API with this library.