### PR TITLE
PLATUI-1224: Remove `maxDuration` from Simulation Setup.

### DIFF
--- a/src/main/scala/uk/gov/hmrc/performance/simulation/PerformanceTestRunner.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/simulation/PerformanceTestRunner.scala
@@ -42,9 +42,6 @@ trait PerformanceTestRunner extends Simulation with HttpConfiguration with Journ
     */
   def runSimulation(): Unit = {
 
-    import scala.concurrent.duration._
-    val timeoutAtEndOfTest: FiniteDuration = 5 minutes
-
     logger.info(s"Setting up simulation ")
 
     if (runSingleUserJourney) {
@@ -62,7 +59,6 @@ trait PerformanceTestRunner extends Simulation with HttpConfiguration with Journ
         .assertions(global.failedRequests.count.is(0))
     } else {
       setUp(withInjectedLoad(journeys): _*)
-        .maxDuration(rampUpTime + constantRateTime + rampDownTime + timeoutAtEndOfTest)
         .protocols(httpProtocol)
         .assertions(global.failedRequests.percent.lte(percentageFailureThreshold))
         .assertions(forAll.failedRequests.percent.lte(requestPercentageFailureThreshold))


### PR DESCRIPTION
Using `maxDuration` will force Gatling to end the simulation even when there are active users. Occasionally this can cause simulation to succeed even when there are active users. See PLATUI-1224 for details.