### PR TITLE
PLATUI-1162: `baseUrl` property removed from application.conf

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -138,8 +138,6 @@ Most of the properties in `application.conf` is commented out by default. This i
 {
 runLocal = true
 
-baseUrl = "https://helloworld-service.co.uk"
-
 perftest {
   rampupTime = 1
   constantRateTime = 5 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory)
   .settings(
-    majorVersion := 4,
+    majorVersion := 5,
     name := "performance-test-runner",
     makePublicallyAvailableOnBintray := true,
     scalaVersion := "2.12.12",

--- a/src/main/scala/uk/gov/hmrc/performance/conf/ServicesConfiguration.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/conf/ServicesConfiguration.scala
@@ -22,11 +22,11 @@ trait ServicesConfiguration extends Configuration {
     if (port.toInt == 80 || port.toInt == 443) s"$protocol://$host" else s"$protocol://$host:$port"
 
   /**
-   * Returns a baseUrl for the provided serviceName based on the serviceName configuration in
-   * `services.conf` or services-local.conf` when running locally.
-   * @param serviceName
-   * @return baseUrl for the service as a String.
-   */
+    * Returns a baseUrl for the provided serviceName based on the serviceName configuration in
+    * `services.conf` or services-local.conf` when running locally.
+    * @param serviceName
+    * @return baseUrl for the service as a String.
+    */
   def baseUrlFor(serviceName: String): String = {
     val protocol = readProperty(s"services.$serviceName.protocol", "")
     val host     = readProperty(s"services.$serviceName.host", "")
@@ -40,10 +40,11 @@ trait ServicesConfiguration extends Configuration {
 
       urlFor(protocolOrDefault, hostOrDefault, portOrDefault)
     } else {
-      val confFile = if (runLocal)
-        "services-local.conf"
-      else
-        "services.conf"
+      val confFile =
+        if (runLocal)
+          "services-local.conf"
+        else
+          "services.conf"
       throw ConfigNotFoundException(s"'$serviceName' not defined in '$confFile'.")
     }
   }

--- a/src/main/scala/uk/gov/hmrc/performance/conf/ServicesConfiguration.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/conf/ServicesConfiguration.scala
@@ -18,15 +18,15 @@ package uk.gov.hmrc.performance.conf
 
 trait ServicesConfiguration extends Configuration {
 
-  private val baseUrl = {
-    val prop = readProperty("baseUrl")
-    if (prop.isEmpty) throw new RuntimeException("baseUrl is mandatory but couldn't be found in application.conf")
-    else prop
-  }
-
   private def urlFor(protocol: String, host: String, port: String) =
     if (port.toInt == 80 || port.toInt == 443) s"$protocol://$host" else s"$protocol://$host:$port"
 
+  /**
+   * Returns a baseUrl for the provided serviceName based on the serviceName configuration in
+   * `services.conf` or services-local.conf` when running locally.
+   * @param serviceName
+   * @return baseUrl for the service as a String.
+   */
   def baseUrlFor(serviceName: String): String = {
     val protocol = readProperty(s"services.$serviceName.protocol", "")
     val host     = readProperty(s"services.$serviceName.host", "")
@@ -40,10 +40,16 @@ trait ServicesConfiguration extends Configuration {
 
       urlFor(protocolOrDefault, hostOrDefault, portOrDefault)
     } else {
-      baseUrl
+      val confFile = if (runLocal)
+        "services-local.conf"
+      else
+        "services.conf"
+      throw ConfigNotFoundException(s"'$serviceName' not defined in '$confFile'.")
     }
   }
 
   def serviceIsDefined(protocol: String, host: String, port: String): Boolean =
     !protocol.isEmpty || !host.isEmpty || !port.isEmpty
+
+  case class ConfigNotFoundException(message: String) extends RuntimeException(message)
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -12,17 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The default url for every service.
-# For example
-# ServicesConfiguration.baseUrlFor("helloworld-service") == https://helloworld-service.co.uk
-baseUrl = "http://helloworld-service.co.uk"
-
-
-# The baseUrl can be overridden in services-local.conf. See that file for more information
-# That file is ignored when the test is not run locally. The default is true
+# Configures the test to run locally. The default value is true. When true, services-local.conf file is used.
 #runLocal = false
-
-
 
 perftest {
 

--- a/src/test/resources/services-local.conf
+++ b/src/test/resources/services-local.conf
@@ -14,9 +14,6 @@
 
 # This file is read when runLocal = true in application.conf (default)
 
-# This can be used to override the 'baseUrl'
-
-# If the service name you are searching is found, baseUrl is overridden.
 # For local development convenience, host and protocol will have the following defaults:
 #      protocol = http
 #      host = localhost

--- a/src/test/resources/services.conf
+++ b/src/test/resources/services.conf
@@ -14,9 +14,6 @@
 
 # This file is read when runLocal = false in application.conf (default is false)
 
-# This can be used to override the 'baseUrl'
-
-# If the service name you are searching is found, baseUrl is overridden.
 # For local development convenience, host and protocol will have the following defaults:
 #      protocol = http
 #      port = 80

--- a/src/test/scala/uk/gov/hmrc/performance/conf/ConfigurationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/performance/conf/ConfigurationSpec.scala
@@ -31,24 +31,6 @@ class ConfigurationSpec extends WordSpec with Matchers {
       configUnderTest.runLocal shouldBe true
     }
 
-    "read a simple property" in {
-
-      val configUnderTest = new Configuration {}
-      configUnderTest.readProperty("baseUrl") shouldBe "http://helloworld-service.co.uk"
-    }
-
-    "give priority to environment variables" in {
-
-      Properties.setProp("baseUrl", "anotherBaseUrl")
-      ConfigFactory.invalidateCaches()
-
-      val configUnderTest = new Configuration {}
-      configUnderTest.readProperty("baseUrl") shouldBe "anotherBaseUrl"
-
-      Properties.clearProp("baseUrl")
-      ConfigFactory.invalidateCaches()
-    }
-
     "read services-local configurations if runLocal = true" in {
 
       val configUnderTest = new Configuration {}

--- a/src/test/scala/uk/gov/hmrc/performance/conf/ServicesConfigurationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/performance/conf/ServicesConfigurationSpec.scala
@@ -39,19 +39,6 @@ class ServicesConfigurationSpec extends WordSpec with Matchers with ServicesConf
       baseUrl shouldBe expectedBaseUrl
     }
 
-    "return the base url if the service is not found" in {
-
-      // given
-      val someService = "incorrectservicename "
-
-      val expectedBaseUrl = "http://helloworld-service.co.uk"
-
-      // when
-      val baseUrl: String = baseUrlFor(someService)
-
-      // then
-      baseUrl shouldBe expectedBaseUrl
-    }
 
     "read services-local configurations if runLocal = true" in {
 
@@ -70,6 +57,25 @@ class ServicesConfigurationSpec extends WordSpec with Matchers with ServicesConf
       Properties.clearProp("runLocal")
       ConfigFactory.invalidateCaches()
     }
-  }
 
+    "throw exception when service is not defined in services-local.conf" in {
+      intercept[ConfigNotFoundException] {
+        baseUrlFor("serviceDoesNotExist")
+      }.message shouldBe s"'serviceDoesNotExist' not defined in 'services-local.conf'."
+    }
+
+    "throw exception when service is not defined in services.conf" in {
+      Properties.setProp("runLocal", "false")
+      ConfigFactory.invalidateCaches()
+
+      val configUnderTest = new ServicesConfiguration {}
+
+      intercept[ConfigNotFoundException] {
+        configUnderTest.baseUrlFor("serviceDoesNotExist")
+      }.message shouldBe s"'serviceDoesNotExist' not defined in 'services.conf'."
+
+      Properties.clearProp("runLocal")
+      ConfigFactory.invalidateCaches()
+    }
+  }
 }

--- a/src/test/scala/uk/gov/hmrc/performance/conf/ServicesConfigurationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/performance/conf/ServicesConfigurationSpec.scala
@@ -39,7 +39,6 @@ class ServicesConfigurationSpec extends WordSpec with Matchers with ServicesConf
       baseUrl shouldBe expectedBaseUrl
     }
 
-
     "read services-local configurations if runLocal = true" in {
 
       val configUnderTest = new ServicesConfiguration {}


### PR DESCRIPTION
* This will be a breaking change for teams using `baseUrl` property.
* Teams should define their service configuration `services.conf` and `services-local.con` as captured in GETTING-STARTED.md