### PR TITLE
NOJIRA remove play-json dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val root = (project in file("."))
     majorVersion := 5,
     name := "performance-test-runner",
     isPublicArtefact := true,
-    scalaVersion := "2.13.8",
+    scalaVersion := "2.13.12",
     //implicitConversions & postfixOps are Gatling recommended -language settings
     scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-language:postfixOps"),
     libraryDependencies ++= Dependencies.compile ++ Dependencies.test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,6 @@ import sbt._
 object Dependencies {
 
   val compile: Seq[ModuleID] = Seq(
-    "com.typesafe.play"    %% "play-json"                 % "2.9.4",
     "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.6.1"
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,6 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build" % "3.9.0")
+addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build" % "3.21.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage"  % "2.0.8")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"   % "2.5.0")

--- a/src/main/scala/uk/gov/hmrc/performance/conf/Configuration.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/conf/Configuration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/performance/conf/HttpConfiguration.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/conf/HttpConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/performance/conf/JourneyConfiguration.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/conf/JourneyConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/performance/conf/PerftestConfiguration.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/conf/PerftestConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/performance/conf/ServicesConfiguration.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/conf/ServicesConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/performance/feeder/CsvFeeder.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/feeder/CsvFeeder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/performance/simulation/Journey.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/simulation/Journey.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/performance/simulation/JourneySetup.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/simulation/JourneySetup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/performance/simulation/PerformanceTestRunner.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/simulation/PerformanceTestRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2023 HM Revenue & Customs
+# Copyright 2024 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/resources/gatling.conf
+++ b/src/test/resources/gatling.conf
@@ -1,4 +1,4 @@
-# Copyright 2023 HM Revenue & Customs
+# Copyright 2024 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/resources/journeys.conf
+++ b/src/test/resources/journeys.conf
@@ -1,4 +1,4 @@
-# Copyright 2023 HM Revenue & Customs
+# Copyright 2024 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/resources/services-local.conf
+++ b/src/test/resources/services-local.conf
@@ -1,4 +1,4 @@
-# Copyright 2023 HM Revenue & Customs
+# Copyright 2024 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/resources/services.conf
+++ b/src/test/resources/services.conf
@@ -1,4 +1,4 @@
-# Copyright 2023 HM Revenue & Customs
+# Copyright 2024 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/performance/conf/ConfigurationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/performance/conf/ConfigurationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/performance/conf/JourneyConfigurationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/performance/conf/JourneyConfigurationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/performance/conf/PerftestConfigurationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/performance/conf/PerftestConfigurationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/performance/conf/ServicesConfigurationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/performance/conf/ServicesConfigurationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/performance/feeder/CsvFeederSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/performance/feeder/CsvFeederSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/performance/simulation/JourneySetupSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/performance/simulation/JourneySetupSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
it's not used in this library, if performance test repos need it then they should depend on it directly

not used by anything in https://github.com/hmrc/performance-testing-template.g8 as far as I can see either, so propose not adding it to that, and letting people add it to their repos if they need it