### PR TITLE
PLATUI-3631: Spike to investigate uplifting Gatling to v3.7.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  private val gatlingVersion = "3.6.1"
+  private val gatlingVersion = "3.7.0"
 
   // The `config` and `gatling-test-framework` libraries are provided so as to be available transitively to services
   // running performance tests using standard HMRC approach

--- a/src/main/scala/uk/gov/hmrc/performance/simulation/Journey.scala
+++ b/src/main/scala/uk/gov/hmrc/performance/simulation/Journey.scala
@@ -21,6 +21,7 @@ import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.core.session.Expression
 import io.gatling.core.structure.{ChainBuilder, ScenarioBuilder}
 import io.gatling.http.request.builder.HttpRequestBuilder
+import io.gatling.javaapi.http.HttpRequestActionBuilder
 
 trait Journey {
   val load: Double
@@ -64,7 +65,7 @@ case class JourneyPart(id: String, description: String) {
     * @return JourneyPart for chaining additional requests, actions, and conditional runs
     */
   def withRequests(requests: HttpRequestBuilder*): JourneyPart = {
-    ab ++= requests.map(r => HttpRequestBuilder.toActionBuilder(r))
+    ab ++= requests.map(r => new HttpRequestActionBuilder(r).asScala())
     this
   }
 

--- a/src/test/scala/uk/gov/hmrc/performance/simulation/JourneySetupSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/performance/simulation/JourneySetupSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.performance.simulation
 
-import io.gatling.core.action.builder.PauseBuilder
+import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.http.request.builder.HttpRequestBuilder
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -37,10 +37,9 @@ class JourneySetupSpec extends AnyWordSpec with Matchers {
   }
 
   class TestActionsSetup extends JourneySetup {
-    val foo: HttpRequestBuilder = http("Get Foo").get(s"/foo")
-    val pause                   = new PauseBuilder(1 milliseconds, None)
-
-    setup("some-id-1", "Some Description 1").withActions(foo, pause)
+    val fooBuilder: HttpRequestBuilder = http("Get Foo").get(s"/foo")
+    val pauseBuilder: ActionBuilder    = pause(Duration(1, MILLISECONDS)).actionBuilders.head
+    setup("some-id-1", "Some Description 1").withActions(fooBuilder, pauseBuilder)
   }
 
   class MalformedTestSetup extends JourneySetup {


### PR DESCRIPTION
# Changes made as part of this PR
The main changes in this PR so far are as follows:
1. In `Journey.scala`, the syntax has changed for creating a new `RequestActionBuilder` - this is due to the underlying DSL changing from Scala to Java, so the syntax is a little different
2. In `CsvFeeder.scala`, rather than calling the native `SeperatedValueParser`, the DSL method `csv(...)` is used instead. It seems that a library changes between v3.6.1 and v3.7.0 is that all the internals are now private to Gatling, and instead file feeder operations have to go via the DSL. However, this was a fairly straightforward syntax change.
3. In `JourneySetupSpec.scala`, the `PauseBuilder` has been made private as per the pattern in Point 2 - so this test uses the `pause` DSL to create a new `ActionBuilder`

# Possible other changes that could be made
1. In `Journey.scala`, the `csv` feeder now no longer includes an explicit call to close the CSV file at the end of the operation. An outstanding question is if / how this can be done via the DSL, and if this is still required.
2. In `CsvFeeder.scala`, it could be good to see if the overridden `.next()` method could be replaced with the use of the DSL `transform` method instead (documentation [here](https://docs.gatling.io/reference/script/core/session/feeders/#transform)).
3. It might be preferable to replace the use of:
```
val ranges: scala.collection.mutable.Map[Int, AtomicLong] = new scala.collection.mutable.HashMap()
```
with 
```
var ranges: Map[Int, Long] = Map()
```

This might make it is easier to understand that this is a mutable variable