### PR TITLE
PLATUI-3701 uplift gatling to 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ If you are using `v6.0.0` of `performance-test-runner`, you can remove the follo
 "com.typesafe"          % "config"                    % "x.x.x" % Test
 ```
 
+### v6.2.0
+If you are upgrading to `v6.2.0` of `performance-test-runner`, you will need to ensure your `gatling-sbt` plugin 
+version is greater than `4.2.0`.
+
 #### License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ adding manually.
 If you are using `v6.0.0` of `performance-test-runner`, you can remove the following from your dependencies
 (e.g. `Dependencies.scala`) as these are now added by the library:
 
-```
+```sbt
 "io.gatling"            % "gatling-test-framework"    % "x.x.x" % Test,
 "io.gatling.highcharts" % "gatling-charts-highcharts" % "x.x.x" % Test,
 "com.typesafe"          % "config"                    % "x.x.x" % Test
@@ -63,6 +63,15 @@ If you are using `v6.0.0` of `performance-test-runner`, you can remove the follo
 ### v6.2.0
 If you are upgrading to `v6.2.0` of `performance-test-runner`, you will need to ensure your `gatling-sbt` plugin 
 version is greater or equal to `4.2.0`.
+
+If you are using CheckBuilder in your performance tests, you would previously have passed in three parameters:
+```scala
+    CheckBuilder[HttpStatusCheckType, Response, Int]
+```
+CheckBuilder now only expects two parameters:
+```scala
+    CheckBuilder[HttpStatusCheckType, Response]
+```
 
 #### License
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you are using `v6.0.0` of `performance-test-runner`, you can remove the follo
 
 ### v6.2.0
 If you are upgrading to `v6.2.0` of `performance-test-runner`, you will need to ensure your `gatling-sbt` plugin 
-version is greater than `4.2.0`.
+version is greater or equal to `4.2.0`.
 
 #### License
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  private val gatlingVersion = "3.7.0"
+  private val gatlingVersion = "3.8.0"
 
   // The `config` and `gatling-test-framework` libraries are provided so as to be available transitively to services
   // running performance tests using standard HMRC approach


### PR DESCRIPTION
# Purpose of PR
- Bump gatling to 3.8.0
  - No further changes needed
  - A small addendum to the README to ensure services check their `sbt-gatling` plugin is upgraded to at least 4.2.0