### PR TITLE
PLATUI-3779 uplift Gatling from 3.11.5 to 3.12.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  private val gatlingVersion = "3.11.5"
+  private val gatlingVersion = "3.12.0"
 
   // The `config` and `gatling-test-framework` libraries are provided so as to be available transitively to services
   // running performance tests using standard HMRC approach


### PR DESCRIPTION
# Purpose of PR
- Uplift Gatling from `3.11.5` to `3.12.0`
- Following the upgrades in 3.11.5, this one works out of the box
  - We don't utilise the `stopInjector` or `stopInjectorIf` methods, so that doesn't affect us
    - These methods are not used across the organisation either
  - We also don't need to worry about them dropping akka here
- As we bumped to 3.11.5 in the last PR, this version bump doesn't require us to do much outside of bumping the version
- Tested against a local performance test and passes unit tests