### PR TITLE
PLATUI-3780: Bumped to Gatling version 3.13.5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  private val gatlingVersion = "3.12.0"
+  private val gatlingVersion = "3.13.5"
 
   // The `config` and `gatling-test-framework` libraries are provided so as to be available transitively to services
   // running performance tests using standard HMRC approach


### PR DESCRIPTION
# Upgrade notes from Gatling 3.12.0 to 3.13.5
## Report writing broken in v3.13.0, do not use that version
When trying to write reports using a version of `performance-test-runner` with Gatling v3.13.0, there is an error:
```
Parsing log file(s)...
[error] java.lang.IllegalArgumentException: Unknown object coding: 1
[error] 	at boopickle.UnpickleState.codingError(Pickler.scala:462)
[error] 	at io.gatling.shared.model.assertion.AssertionPicklers$Picklers$Pickler$macro$23$1$.unpickle(AssertionPicklers.scala:47)
[error] 	at io.gatling.shared.model.assertion.AssertionPicklers$Picklers$Pickler$macro$23$1$.unpickle(AssertionPicklers.scala:47)
[error] 	at boopickle.CompositePickler.unpickle(CompositePicklers.scala:40)
[error] 	at boopickle.UnpickleState.unpickle(Pickler.scala:497)
```

Haven't been able to definitively track down documentation about this, but we can demonstrate that it works in v3.13.5 and not in v3.13.0. 


## Using in a test repository with Gatling 3.13.5
When bumping to Gatling 3.13.5, the library compiles + tests + builds without any issue.

However, when we try to run these tests, there is an error:
https://github.com/hmrc/epaye-frontend-performance-tests

This is because the signature of CheckBuilder has changed:
```
// Gatling 3.6.1:
trait CheckBuilder[T, P, X] {
  def name(n: String): CheckBuilder[T, P, X]
  def saveAs(key: String): CheckBuilder[T, P, X]
  def build[C <: Check[R], R](materializer: CheckMaterializer[T, C, R, P]): C
}

// Gatling 3.13.0
trait CheckBuilder[T, P] {
  def build[C <: Check[R], R](materializer: CheckMaterializer[T, C, R, P]): C
}
```

There is a [code change needed here](https://github.com/hmrc/epaye-frontend-performance-tests/blob/main/src/test/scala/uk/gov/hmrc/perftests/epaye/utils/Checks.scala#L21-L22) like this:

```
// Previous
def statusOk: CheckBuilder[HttpStatusCheckType, Response, Int]       = status.is(200)
def statusRedirect: CheckBuilder[HttpStatusCheckType, Response, Int] = status.is(303)

// Updated
def statusOk: CheckBuilder[HttpStatusCheckType, Response]       = status.is(200)
def statusRedirect: CheckBuilder[HttpStatusCheckType, Response] = status.is(303)
```